### PR TITLE
Change zram_num_devices to num_devices

### DIFF
--- a/openrc/init.d/zram-init
+++ b/openrc/init.d/zram-init
@@ -44,7 +44,7 @@ start() {
 
 	if yesno "${load_on_start}"
 	then	einfo "Loading zram module..."
-		modprobe zram "zram_num_devices=${num_devices}"
+		modprobe zram "num_devices=${num_devices}"
 		eend ${?}
 	fi
 


### PR DESCRIPTION
In Linux 3.2 and 3.3 only, the parameter is called "zram_num_devices" Every other version of Linux (up to the current version 3.8) uses "num_devices" as the parameter.
