### PR TITLE
Proposed fix for systemd-hostnamed PrivateTmp=yes

### DIFF
--- a/systemd/system/zram_var_tmp.service
+++ b/systemd/system/zram_var_tmp.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Mount /var/tmp as zram
+DefaultDependencies=no
 Conflicts=umount.target
-After=local-fs.target
-Before=umount.target display-manager.service
+Before=local-fs.target umount.target
 
 [Service]
 Type=oneshot
@@ -18,4 +18,4 @@ ExecStart=/sbin/zram-init -d2 -s2 -alz4 -text4 -orelatime -m1777 -Lvar_tmp_dir 2
 ExecStop=/sbin/zram-init -d2 0 /var/tmp
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=local-fs-pre.target


### PR DESCRIPTION
systemd-hostnamed by default uses /var/tmp/ and create a private
folder, service usually spawned by NetworkManager. So when
zram-init tries to mount /var/tmp, makes systemd folder
unavailable, making the whole service to fail with error 226/NAMESPACE

In order to fix that, my proposal requires modifying the service to
wait after network.target to run the service.