### PR TITLE
Fix missing newline for backing_dev

### DIFF
--- a/sbin/zram-init
+++ b/sbin/zram-init
@@ -251,7 +251,7 @@ else	[ -z "$streams" ] || SysCtl "$streams" "$block/max_comp_streams" || \
 	[ -z "$algo" ] || SysCtl "$algo" "$block/comp_algorithm" || \
 		Warning "warning: failed to set zram$dev comp_algorithm to $algo"
 	[ -z "${backing_dev:++}" ] || \
-		SysCtl "$backing_dev" "$block/backing_dev" || \
+		Echo "$backing_dev" >| "$block/backing_dev" || \
 		Warning "warning: failed to set zram$dev backing_dev"
 	SysCtl "$size" "$block/disksize" || Fatal "cannot set zram$dev size"
 fi


### PR DESCRIPTION
backing_dev requires trailing newline which is missing in the SysCtl function.

Tested on kernel 4.15 shipped with Ubuntu bionic
Linux ___ 4.15.0-20-generic #21-Ubuntu SMP Tue Apr 24 06:16:15 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
