### PR TITLE
Correctly resolve args

### DIFF
--- a/openrc/init.d/zram-init
+++ b/openrc/init.d/zram-init
@@ -59,7 +59,7 @@ ZramIgnore() {
 		labl=\${labl$1-}
 		uuid=\${uuid$1-}
 		notr=\${notr$1-}
-		args=\${uuid$1-}"
+		args=\${args$1-}"
 	case $fstype in
 	swap|/*)
 		! [ "$size" -gt 0 ];;


### PR DESCRIPTION
Due to a copy'n'paste mistake, the uuid variable is being resolved
instead of the args variable. This commit fixes this wrong behavior.