### PR TITLE
fix bad `sed` statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ MANDIR      ?= $(DESTDIR)$(PREFIX)/share/man
 MANSUBDIR   ?= man8
 MANI18NAPP  ?=
 MODIR       ?= $(DESTDIR)$(PREFIX)/share/locale
+MODIR_SED   ?= $(MODIR)
 COMP_ZSHDIR ?= $(DESTDIR)$(PREFIX)/share/zsh/site-functions
 SYSTEMDDIR  ?= $(DESTDIR)$(PREFIX)/lib/systemd/system
 CONFDIR     ?= $(DESTDIR)$(SYSCONFDIR)/conf.d
@@ -66,7 +67,7 @@ i18n/%.mo: i18n/%.po
 
 sbin/$(EXENAME): sbin/$(EXENAME).in
 	@echo 'Setting TEXTDOMAINDIR and TEXTDOMAIN variables'
-	sed -e "s'@MODIR@'$(MODIR)'g" -e "s'@EXENAME@'$(EXENAME)'g" \
+	sed -e "s'@MODIR@'$(MODIR_SED)'g" -e "s'@EXENAME@'$(EXENAME)'g" \
 		-- '$<' >'$@'
 	chmod 755 -- '$@' || echo 'warn: chmod 755 $@ failed'
 ifeq ($(MODIFY_SHEBANG), TRUE)


### PR DESCRIPTION
In some cases, we need the `TEXTDOMAINDIR` variable to be different from the installation directory of the locales: for example, an **ebuild** temporarily installs the files in _${D}_ before installing them in the system: the locales should be installed in _${D}/usr/share/locales_ but `TEXTDOMAINDIR` should be equal to _/usr/share/locales_.