### PR TITLE
[zram-init.in] fix opening brace in variable ref.

### DIFF
--- a/sbin/zram-init.in
+++ b/sbin/zram-init.in
@@ -385,7 +385,7 @@ else	[ -z "$streams" ] || SysCtl "$streams" "$block/max_comp_streams" \
 }
 	! $writeback || InitWriteback
 fi
-[ -z "$mem_limit" ] || SysCtl "$[mem_limit}M" "$block/mem_limit" || \
+[ -z "$mem_limit" ] || SysCtl "${mem_limit}M" "$block/mem_limit" || \
 	xWarning 'failed to set zram${dev} mem_limit'
 
 eval "set -- a $mkfs_opt"


### PR DESCRIPTION
This fixes a typo introduced by 24949d8
which broke the `zram-init` script.