### PR TITLE
Fix issue with X-mount.mkdir mount option

### DIFF
--- a/sbin/zram-init.in
+++ b/sbin/zram-init.in
@@ -277,7 +277,7 @@ then	swap=false
 	dir=${2%/}
 	if [ x"$dir" = x'-' ]
 	then	mount=false
-	elif [ -z "$dir" ] || ! test -d "$dir"
+        elif ([ -z "$dir" ] || ! test -d "$dir") && ! echo "$opts" | grep -iq 'X-mount\.mkdir'
 	then	if $umount
 		then	xWarning '${dir:-(empty)} is not a directory. Umounting anyway'
 		else	xFatal '${dir:-(empty)} is not a directory'


### PR DESCRIPTION
This fixes #35 

My solution was to simply check if `X-mount.mkdir` was used and if so don't trigger the "is not a directory" error.

This patch works for me and I think it's "good enough" for such a corner case but I could envision more elaborate options, like `zram-init` handling the directory creation itself or perhaps to be more accurate explicitly check if `$dir` exists and is not a directory to trigger the error and only check for `X-mount.mkdir` if `$dir` is really not existent.

Also, using `grep` this way may no be the best portable way but I figure `zram-init` will be only used on modern linux distros anyway.

Thoughts?