### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ A __zram-init__ package is available.
 
 ### Arch based
 
-To install on Arch based distribution: install `zram-init-git` from AUR
+To install on Arch based distribution: install `zram-init` from AUR
 
 Once installed, configure:
 ```


### PR DESCRIPTION
* change AUR package name to zram-init
** zram-init-git is no longer maintained

Solves: https://github.com/vaeth/zram-init/issues/39