### PR TITLE
Fix `algorithm_params` support

### DIFF
--- a/openrc/conf.d/zram-init
+++ b/openrc/conf.d/zram-init
@@ -97,7 +97,7 @@ owgr1= # No reason to change the default "root:root"
 notr1= # keep the default on linux-3.15 or newer
 maxs1=2
 algo1=zstd
-para1="algo=zstd level=22" # or "algo=zstd level=22 dict=/etc/dictionary"
+para1="level=3" # algorithm-specific parameters such as compression level
 labl1=tmp_dir
 uuid1=
 args1=

--- a/sbin/zram-init.in
+++ b/sbin/zram-init.in
@@ -207,7 +207,7 @@ do	case $opt in
 	s)	streams=$OPTARG;;
 	S)	mem_limit=$OPTARG;;
 	a)	algo=$OPTARG;;
-	a)	algo_params=$OPTARG;;
+	A)	algo_params=$OPTARG;;
 	b)	backing_dev=$OPTARG;;
 	I)	incompressible=:;;
 	c)	owgr=$OPTARG;;

--- a/systemd/system/zram_btrfs.service
+++ b/systemd/system/zram_btrfs.service
@@ -15,7 +15,7 @@ RemainAfterExit=true
 # zram_swap.service, zram_var_tmp.service, zram_tmp.service, and
 # that num_devices in modprobe.d/zram.conf contains the maximal used number + 1
 
-ExecStart=/sbin/zram-init -d1 -s2 -azstd -A "algo=zstd level=22" -tbtrfs -Lzbtrfs 2048 -
+ExecStart=/sbin/zram-init -d1 -s2 -azstd -A "algo=zstd level=3" -tbtrfs -Lzbtrfs 2048 -
 ExecStop=/sbin/zram-init -d1 0 -
 
 [Install]

--- a/systemd/system/zram_var_tmp.service
+++ b/systemd/system/zram_var_tmp.service
@@ -15,7 +15,7 @@ RemainAfterExit=true
 # zram_swap.service and zram_tmp.service and
 # that num_devices in modprobe.d/zram.conf contains the maximal used number + 1
 
-ExecStart=/sbin/zram-init -d2 -s2 -azstd -A "algo=zstd level=22" -text4 -orelatime -m1777 -Lvar_tmp_dir 2048 /var/tmp
+ExecStart=/sbin/zram-init -d2 -s2 -azstd -A "algo=zstd level=3" -text4 -orelatime -m1777 -Lvar_tmp_dir 2048 /var/tmp
 ExecStop=/sbin/zram-init -d2 0 /var/tmp
 
 [Install]


### PR DESCRIPTION
This PR fixes the `-A` parameter and changes compression level suggested by default configuration back to `3` (which is default clevel in Linux).
`22` level is the maximum compression in `zstd` which takes a lot of CPU time, it's totes not what most users would want by default in `/tmp` or `/var/tmp/portage`.