### PR TITLE
"Fixes" (aleviates) a race condition???

### DIFF
--- a/openrc/init.d/zram-init
+++ b/openrc/init.d/zram-init
@@ -81,6 +81,7 @@ start() {
 	if yesno "$load_on_start"
 	then	einfo 'Loading zram module...'
 		modprobe zram "num_devices=$num_devices"
+		sleep 1
 		eend $?
 	fi
 


### PR DESCRIPTION
First off this is not good code and i don't expect you to actually merge this. But if you do it will "fix" the issue.

It seems i found a race condition where the script attempts to initialize the zram device before the kernel module is finished loading. This only occurs on one of my devices. But this fixes it for me. i just added sleep 1 right after the modprobe to give it more time to load. This is not a good fix. It's a hack job. It would probably be better to check to see if the module is finished loading and then continue with the script.

I would have thought that the modprobe command exits when the module is done loading but that doesn't seem to be the case.


#check out this hardware specific intermittent linux kernel/userspace race condition i found.

/etc/init.d/zram-init start
echo '#fails on boot'

/etc/init.d/zram-init start
/etc/init.d/zram-init stop
/etc/init.d/zram-init start
echo '#fails'


/etc/init.d/zram-init stop
modprobe zram
/etc/init.d/zram-init start
echo '#sucess'


modprobe zram
/etc/init.d/zram-init start
echo '#sucess on boot'

error output:
 * Loading zram module...                                                                                                                                                   [ ok ]
 * Swap->zram0
zramctl: /dev/zram0: failed to reset: Device or resource busy
zram-init: 
zramctl zram0 failed