### PR TITLE
Fix typo in ChangeLog: xz-de -> xz-dev

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,7 +10,7 @@
 	  See the discussion in https://github.com/vaeth/zram-init/issues/56
 
 *zram-init-13.1:
-	Xiangzhe (https://github.com/xz-de):
+	Xiangzhe (https://github.com/xz-dev):
 	- Fix order for openrc
 
 *zram-init-13.0:


### PR DESCRIPTION
Fixed typo in ChangeLog for zram-init-13.1 entry, changed incorrect GitHub username `xz-de` to `xz-dev`