### PR TITLE
openrc: retry initialisation if it fails

### DIFF
--- a/openrc/conf.d/zram-init
+++ b/openrc/conf.d/zram-init
@@ -4,6 +4,12 @@
 # load zram kernel module on start?
 load_on_start=yes
 
+# how long to sleep initially for the module to finish loading
+module_wait=0
+
+# how many times to retry initialising a device
+init_retry=10
+
 # unload zram kernel module on stop?
 unload_on_stop=yes
 

--- a/openrc/init.d/zram-init
+++ b/openrc/init.d/zram-init
@@ -24,7 +24,9 @@ ZramInit() {
 			${mode:+-m "$mode"} \
 			${1+"$@"} -- "$size" "$fstype"
 	fi
-	eend $?
+	rc=$?
+	eend $rc
+	return $rc
 }
 
 ZramStop() {
@@ -80,13 +82,22 @@ start() {
 	if yesno "$load_on_start"
 	then	einfo 'Loading zram module...'
 		modprobe zram "num_devices=$num_devices"
-		sleep 1
+		sleep "${module_wait:-0}"
 		eend $?
 	fi
 
 	i=0
 	while [ $i -lt "$num_devices" ]
-	do	ZramIgnore "$i" || ZramInit -d "$i"
+	do
+		if ! ZramIgnore "$i"; then
+			n="${init_retry:-10}"
+			while ! ZramInit -d "$i"; do
+				let --n
+				[ "$n" -gt "0" ] || break
+				einfo "Retrying in a second..."
+				sleep 1
+			done
+		fi
 		i=$(( $i + 1 ))
 	done
 	:


### PR DESCRIPTION
The kernel module can take some time to be ready, and 1 second is often not long enough

Probably fixes #62