### PR TITLE
Remove '-s NUM' option from zram-init man page

### DIFF
--- a/man/zram-init.8
+++ b/man/zram-init.8
@@ -41,9 +41,6 @@ If modprobe needs to be used, require \fINUM\fR devices.
 .br
 This is not recommended. Rely instead on \fI\,/etc/modprobe.d/zram.conf\/\fP with the line options zram num_devices=\fINUM\fR.
 .TP
-.BR "\-s " \fINUM
-Use up to \fINUM\fR parallel compression streams for the device.
-.TP
 .BR "\-S " \fIMAX
 Use maximally \fIMAX\fR megabytes of uncompressed memory for the device.
 .TP


### PR DESCRIPTION
Removed option '-s NUM' for parallel compression streams from man page

#64 